### PR TITLE
Make year range absolute, swap order of year range

### DIFF
--- a/root/src/main.js
+++ b/root/src/main.js
@@ -4,7 +4,7 @@
      dateFormat: "yy-mm",
      changeMonth: true,
      changeYear: true,
-     yearRange: "c-120:c-17"
+     yearRange: "-17:-120"
     });
 
     jQuery('#payment_button').click(function() {


### PR DESCRIPTION
Removing the anchors to the currently selected date should fix the ongoing datepicker bug

Swapping the year range order should make DoB selection easier as members are more likely to be closer to -17 than -120