### PR TITLE
/tools can now (again) list all with no parameters

### DIFF
--- a/lib/AccessSystem/Schema/ResultSet/Tool.pm
+++ b/lib/AccessSystem/Schema/ResultSet/Tool.pm
@@ -10,12 +10,12 @@ sub find_tool {
     my ($self, $input, $args, $rc_class) = @_;
 
     my $tools = $self->search_rs({ 'me.name' => $input }, $args);
-    $tools->result_class($rc_class);
+    $tools->result_class($rc_class) if $rc_class;
     if ($tools->count == 1) {
         return ($tools->first, $tools);
     }
     $tools = $self->search_rs({ 'me.name' => { '-like' => "%$input%" }}, $args);
-    $tools->result_class($rc_class);
+    $tools->result_class($rc_class) if $rc_class;
     my $tool;
     if ($tools->count == 1) {
         $tool = $tools->first;
@@ -26,13 +26,13 @@ sub find_tool {
         my $pgtools = $self->search_rs({ 'me.name' => { '-ilike' => "%$input%" }}, $args);
         if ($pgtools->count) {
             $tools = $pgtools;
-            $tools->result_class($rc_class);
+            $tools->result_class($rc_class) if $rc_class;
         }
         if ($tools->count == 1) {
             $tool = $tools->first;
         }
     } catch {
-        print "This is not Pg: $_\n";
+        print "This is not Pg: (no ILIKE)\n";
     };
     return ($tool, $tools) if $tool;
     

--- a/lib/AccessSystem/TelegramBot.pm
+++ b/lib/AccessSystem/TelegramBot.pm
@@ -302,12 +302,19 @@ Output a list of tool names.
 
 sub tools ($self, $text, $message) {
     my $tools = $self->db->resultset('Tool');
-    my $name_match = '%';
+    $tools->result_class('DBIx::Class::ResultClass::HashRefInflator');
     if ($text =~ m{/tools ([\w\d\s]+)}) {
         (undef, $tools) = $tools->find_tool($1, undef, 'DBIx::Class::ResultClass::HashRefInflator');
     }
 
-    my $tool_str = join("\n", map { $_->{name} . ($_->{requires_induction} ? ' (induction)' : '') } ($tools->all));
+    my $tool_str = join("\n",
+                        map {
+                            $_->{name} . ($_->{requires_induction}
+                                            ? ' (induction)'
+                                            : '')
+                        }
+                        grep { $_->{name} !~ /oneall_login_callback/ }
+                        ($tools->all));
     $tool_str ||= '<None found>';
     $message->reply($tool_str);
 }


### PR DESCRIPTION
I did a stupid, now fixed
Also filtered out the "oneall" non-tool for less confusion