### PR TITLE
Castaway/payment refs

### DIFF
--- a/script/delete_ex_members.pl
+++ b/script/delete_ex_members.pl
@@ -1,0 +1,35 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+# use local::lib '/usr/src/perl/libs/access_system/perl5';
+use Config::General;
+use DateTime;
+
+use lib "$ENV{CATALYST_HOME}/lib";
+use AccessSystem::Schema;
+
+# Read config to get db connection info:
+my %config = Config::General->new("$ENV{CATALYST_HOME}/accesssystem_api_local.conf")->getall;
+my $schema = AccessSystem::Schema->connect(
+    $config{'Model::AccessDB'}{connect_info}{dsn},
+    $config{'Model::AccessDB'}{connect_info}{user},
+    $config{'Model::AccessDB'}{connect_info}{password},
+    );
+
+my @people = ();
+foreach my $person ($schema->resultset('Person')->all) {
+    next if $person->valid_until;
+    next if $person->created_date > DateTime->new(year => 2022,
+                                                  month => 2,
+                                                  day => 1
+        );
+    next if $person->tokens->count > 0;
+    print $person->name, "\n";
+    push @people, $person->id;
+}
+
+my $to_delete = $schema->resultset('Person')->search({ id => \@people });
+print "Found: " . $to_delete->count, "\n";
+#$to_delete->delete;

--- a/script/update_payments.pl
+++ b/script/update_payments.pl
@@ -1,5 +1,8 @@
 #!/usr/bin/perl
 
+use strict;
+use warnings;
+
 # use local::lib '/usr/src/perl/libs/accesssystem/perl5';
 use Config::General;
 use DateTime;
@@ -72,9 +75,9 @@ $schema->resultset('Person')->update_member_register();
 
 sub fiddle_payment {
     my ($trans) = @_;
-    $trn->{name} =~ s/o/0/gi;
-    $trn->{name} =~ s/ sm/SM/ig;
-    $trn->{name} =~ s/ SN/ SM/gi;
+    $trans->{name} =~ s/o/0/gi;
+    $trans->{name} =~ s/ sm/SM/ig;
+    $trans->{name} =~ s/ SN/ SM/gi;
 
     ## Mr Netting paid to wrong membership ID (twice):
     if($trans->{name} =~ /K WALLBANK/) {


### PR DESCRIPTION
Oops, messed up the payments importing code last time I changed it: Now actually checks for lower case "sm", spaces, and letter O instead of number 0. Also turns on strict syntax checking, dunno which idiot didnt do that originally!