### PR TITLE
Add ability to delete tokens and vehicles

### DIFF
--- a/lib/AccessSystem/API/Controller/Root.pm
+++ b/lib/AccessSystem/API/Controller/Root.pm
@@ -228,6 +228,33 @@ sub delete_me :Chained('logged_in'): PathPart('deleteme'): Args(0) {
     }
 }
 
+sub delete_token :Chained('logged_in'): PathPart('delete_token'): Args(0) {
+    my ($self, $c) = @_;
+    my $token = $c->req->params->{token};
+
+    # These are GET reqs (cos lazy, and its a link)
+    # Must retain at least one token
+    if($c->stash->{person} && $c->stash->{person}->tokens_rs->count > 1) {
+        my $token_obj = $c->stash->{person}->tokens_rs->find({ id => $token });
+        if($token_obj) {
+            $token_obj->delete();
+        }
+    }
+    return $c->response->redirect($c->uri_for('profile'));
+}
+
+sub delete_vehicle :Chained('logged_in'): PathPart('delete_vehicle'): Args(0) {
+    my ($self, $c) = @_;
+    my $vehicle = $c->req->params->{vehicle};
+
+    # These are GET reqs (cos lazy, and its a link)
+    my $vehicle_obj = $c->stash->{person}->vehicles_rs->find({ plate_reg => $vehicle });
+    if($vehicle_obj) {
+        $vehicle_obj->delete();
+    }
+    return $c->response->redirect($c->uri_for('profile'));
+}
+
 sub who : Chained('base') : PathPart('who') : Args(0)  {
     my ($self, $c) = @_;
 

--- a/root/src/profile.tt
+++ b/root/src/profile.tt
@@ -29,13 +29,13 @@
 
 <div class="col-lg-12"><strong>Your Vehicles:</strong></div>
 [% FOREACH vehicle = person.vehicles %]
-  <div class="col-lg-10 offset-2"> Plate: <strong>[% vehicle.plate_reg %]</strong> <a class="confirm" href="[% c.uri_for('delete_vehicle', { id => vehicle.plate_reg }) %]">Delete</a> </div>
+  <div class="col-lg-10 offset-2"> Plate: <strong>[% vehicle.plate_reg %]</strong> <a class="confirm" href="[% c.uri_for('delete_vehicle', { vehicle => vehicle.plate_reg }) %]">Delete</a> </div>
 
 [% END %]
 
 <div class="col-lg-12"><strong>Your Access Tokens:</strong></div>
 [% FOREACH token = person.tokens %]
-  <div class="col-lg-10 offset-2"> ID: <strong>[% token.id %]</strong> [% token.type %] [% IF person.tokens_rs.count > 1 %] <a class="confirm" href="[% c.uri_for('delete_token', { id => token.id }) %]">Delete</a> [% END %] </div>
+  <div class="col-lg-10 offset-2"> ID: <strong>[% token.id %]</strong> [% token.type %] [% IF person.tokens_rs.count > 1 %] <a class="confirm" href="[% c.uri_for('delete_token', { token => token.id }) %]">Delete</a> [% END %] </div>
  [% END %]
 
 <div class="col-lg-12"><strong>Your Inductions:</strong></div>

--- a/root/src/wrapper.tt
+++ b/root/src/wrapper.tt
@@ -38,6 +38,6 @@
   crossorigin="anonymous"></script>
    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
   <script src="//code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
-  <!-- <script src="[% c.uri_for('assets/js/access.js') %]"></script> -->
+  <script src="[% c.uri_for('assets/js/access.js') %]"></script>
   </body>
 </html>


### PR DESCRIPTION
Fixes #10

* Re-added the js "confirm" dialog (cant remember why we removed it) - possibly need to add `RequestHeader set X-Forwarded-Proto "https"` to the apache config for this to work
*  Added token_delete and vehicle_delete which remove one token or vehicle at a time. The token one will not allow the last token to be removed.
* Tweaked profile template for more readable links