### PR TITLE
Add devcontainer image and GH Action build

### DIFF
--- a/.github/workflows/build-dev-image.yaml
+++ b/.github/workflows/build-dev-image.yaml
@@ -1,8 +1,6 @@
 name: Build Dev Container Base Image
 
 on:
-  schedule:
-    - cron: '0 8 1 * *' # Scheduled at 08:00 on the first day of every month
   push:
     branches:
       - master

--- a/.github/workflows/build-dev-image.yaml
+++ b/.github/workflows/build-dev-image.yaml
@@ -14,6 +14,7 @@ on:
 env:
   CONTAINER_REGISTRY: ghcr.io
   IMAGE_NAME: access-system-dev
+  BRANCH_NAME: ${{ github.head_ref || github.ref }} 
 
 jobs:
   build:
@@ -35,12 +36,13 @@ jobs:
     - name: 💾 Push image
       run: |
         IMAGE_ID=$CONTAINER_REGISTRY/$GITHUB_REPOSITORY_OWNER/$IMAGE_NAME
-        echo "Image ID: $IMAGE_ID"
-        echo "GITHUB_SHA: $GITHUB_SHA"
+        VERSION=$(echo "${BRANCH_NAME#refs/heads/}" | sed -e 's/[^a-zA-Z0-9]/-/g') # Get the branch name from the ref and replace non-alphanumeric characters with hyphens
+        [ "$VERSION" == "master" ] && VERSION=latest
+        echo "🆔 Image ID: $IMAGE_ID"
+        echo "#️⃣ GITHUB_SHA: $GITHUB_SHA"
+        echo "🎯 Version: $VERSION"
+        echo "🚀 Pushing image to registry........................................."
         docker tag $IMAGE_NAME $IMAGE_ID:$GITHUB_SHA
         docker push $IMAGE_ID:$GITHUB_SHA
-        VERSION=$(echo "$GITHUB_REF_NAME" | sed -e 's/[^a-zA-Z0-9]/-/g') # Get the branch name from the ref and replace non-alphanumeric characters with hyphens
-        [ "$VERSION" == "master" ] && VERSION=latest
-        echo "Version: $VERSION"
         docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
         docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/build-dev-image.yaml
+++ b/.github/workflows/build-dev-image.yaml
@@ -1,0 +1,46 @@
+name: Build Dev Container Base Image
+
+on:
+  schedule:
+    - cron: '0 8 1 * *' # Scheduled at 08:00 on the first day of every month
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch: # Manually triggered
+
+env:
+  CONTAINER_REGISTRY: ghcr.io
+  IMAGE_NAME: access-system-dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: 📦 Checkout code
+      uses: actions/checkout@v4
+
+    - name: 🏗️ Build image
+      run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID},sha=${GITHUB_SHA},ref=${GITHUB_REF}"
+
+    - name: 🔐 Log in to registry
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login $CONTAINER_REGISTRY -u $ --password-stdin
+
+    - name: 💾 Push image
+      run: |
+        IMAGE_ID=$CONTAINER_REGISTRY/$GITHUB_REPOSITORY_OWNER/$IMAGE_NAME
+        echo "Image ID: $IMAGE_ID"
+        echo "GITHUB_SHA: $GITHUB_SHA"
+        docker tag $IMAGE_NAME $IMAGE_ID:$GITHUB_SHA
+        docker push $IMAGE_ID:$GITHUB_SHA
+        VERSION=$(echo "$GITHUB_REF_NAME" | sed -e 's/[^a-zA-Z0-9]/-/g') # Get the branch name from the ref and replace non-alphanumeric characters with hyphens
+        [ "$VERSION" == "master" ] && VERSION=latest
+        echo "Version: $VERSION"
+        docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+        docker push $IMAGE_ID:$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+
+FROM mcr.microsoft.com/devcontainers/base:buster
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        perl=5.28.1-6+deb10u1 \
+        cpanminus \
+        libalgorithm-diff-perl \
+        libalgorithm-diff-xs-perl \
+        libalgorithm-merge-perl \
+        libcgi-fast-perl \
+        libcgi-pm-perl \
+        libclass-accessor-perl \
+        libclass-isa-perl \
+        libencode-locale-perl \
+        libfcgi-perl \
+        libfile-fcntllock-perl \
+        libhtml-parser-perl \
+        libhtml-tagset-perl \
+        libhttp-date-perl \
+        libhttp-message-perl \
+        libio-html-perl \
+        libio-string-perl \
+        liblocale-gettext-perl \
+        liblwp-mediatypes-perl \
+        libparse-debianchangelog-perl \
+        libsub-name-perl \
+        libswitch-perl \
+        libtext-charwidth-perl \
+        libtext-iconv-perl \
+        libtext-wrapi18n-perl \
+        libtimedate-perl \
+        liburi-perl \
+        libscalar-list-utils-perl \
+    && cpanm -S Carton \
+# for Perl::LanguageServer
+    && apt-get -y install  --no-install-recommends \
+        libanyevent-perl \
+        libclass-refresh-perl \
+        libdata-dump-perl \
+        libio-aio-perl \
+        libjson-perl \
+        libmoose-perl \
+        libpadwalker-perl \
+        libscalar-list-utils-perl \
+        libcoro-perl \
+    && cpanm Perl::LanguageServer \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
To speed up `devcontainer` starts, build a partial image and use that as a base image for development.

Container images are stored at https://github.com/swindonmakers/AccessSystem/pkgs/container/access-system-dev

There are 3 triggers for image builds:
- manually triggered (mostly for debugging reasons)
- when a PR is created (and on each push to PR): this will create two tags per build; one for git commit `sha` and one for  `branch-name`. The `sha` tag considered immutable, a new one is created for each consequent commit, the `branch-name` is a floating (moving) tag, always points to the latest commit sha on the branch.
- when a branch is merged to `master`: this will create two tags, one for `sha` and one (per convention) `latest` that points to the `HEAD` of the `master`  branch.

Generally `latest` should be used for `devcontainer`, others are for supporting infra changes if needed.