### PR TITLE
Remove ex member inductions (code, needs calling from somewhere)

### DIFF
--- a/NOTES.txt
+++ b/NOTES.txt
@@ -313,3 +313,34 @@ Dec 2023
 * TODO: add / fix tests! eg using https://metacpan.org/pod/Email::Sender::Transport::Test
 
 # carton exec script/accesssystem_api_server.pl --port 9001 &
+
+March 2024
+
+    my $chat_id = $message->chat->id;
+    my $chat = $message->_brain->getChat($chat_id);
+    my $response = '';
+
+    say "Chat";
+    #say Dumper($chat);
+    
+    say "active_usernames: ". $chat->active_usernames;
+    say Dumper($chat->active_usernames);
+
+    if(!$chat->active_usernames || !@{$chat->active_usernames}) {
+        return $message->reply("Can't get chat usernames!\n");
+    }
+    my $all_members_rs = $self->db->resultset('Person')->search_rs({ telegram_username => { '-in' => $chat->active_usernames } });
+    # $all_members_rs->result_class('DBIx::Class::ResultClass::HashRefInflator');
+    # bonus exercise: users in active_usernames who are not in all_members
+    # my @missing = grep 
+    foreach my $member ($all_members_rs->all) {
+        if(!$member->is_valid) {
+            $response .= "\n" . $member->name . " is no longer paid-up.";
+        } else {
+            $response .= "\n" . $member->name . " is ok.";
+        }        
+    }
+
+    return $message->reply($response);
+
+.. members_only tidyup .. it appears that "active_members" returns "sod all" even tho its an admin and a supergroup.. so redone this in a different fashion!

--- a/cpanfile
+++ b/cpanfile
@@ -39,5 +39,6 @@ requires 'Try::Tiny';
 requires 'Text::CSV_XS';
 requires 'Feature::Compat::Try';
 requires 'Email::Sender::Simple';
-requires 'Email::Sender::Transport::SMTP';
+requires 'Email::Sender::Transport::SMTP'; 
 requires 'DBIx::Class::EasyFixture';
+requires 'Time::HiRes';

--- a/lib/AccessSystem/API/Controller/v2.pm
+++ b/lib/AccessSystem/API/Controller/v2.pm
@@ -1,0 +1,69 @@
+package AccessSystem::API::Controller::v2;
+
+use Moose;
+
+BEGIN { extends 'Catalyst::Controller' }
+
+__PACKAGE__->config(namespace => 'accesssystem');
+
+=encoding utf-8
+
+=head1 NAME
+
+AccessSystem::API::Controller::v2 - API v2 Controller
+
+=head1 DESCRIPTION
+
+This one should have some sorta auth protection on it, and should log all uses. 
+
+(Move all non-UI methods here from Root)
+
+=head1 METHODS
+
+=cut
+
+sub authenticated :Chained('/') :PathPart('v2') :CaptureArgs(0) {
+}
+
+sub remove_ex_member_inductions: Chained('authenticated'): PathPart('remove_ex_member_inductions'): Args(1) {
+    my ($self, $c, $num_months) = @_;
+
+    # Magic number, should probably be in a config file...
+    my $induction_expiry_months = 3;
+
+    if($num_months =~ /\D/) {
+        $c->stash(json => {
+            error => 'remove_ex_member_inductions takes a number parameter',
+                  }
+            );
+        return $c->forward('View::JSON');
+    }
+    
+    my $ex_members = $c->model('AccessDB::Person')->ex_members($num_months, {}, $induction_expiry_months);
+
+    # inductions, all of em (door will get re-added when they rejoin, see PR:90
+    # $ex_members->as_subselect_rs->related_resultset('allowed')->count;
+    $ex_members->related_resultset('allowed')->delete;
+
+
+    $c->stash(json => {
+        success => 1,
+              }
+        );
+    return $c->forward('View::JSON');
+}
+
+=head1 AUTHOR
+
+Jess Robinson
+
+=head1 LICENSE
+
+This library is free software. You can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/AccessSystem/TelegramBot.pm
+++ b/lib/AccessSystem/TelegramBot.pm
@@ -12,6 +12,7 @@ use LWP::Simple;
 use LWP::UserAgent;
 use Text::Fuzzy;
 use JSON 'decode_json';
+use Time::HiRes 'usleep';
 use lib "$ENV{BOT_HOME}/lib";
 use AccessSystem::Schema;
 use AccessSystem::Emailer;
@@ -88,17 +89,13 @@ Only allowed via private message.
 
     'director'
 
-Only allowed for directors (inductors on the door).  Implies private.
+Only allowed for directors (inductors on the door).
 
 =cut
 
 sub authorize ($self, $message, @tags) {
     my $member = $self->member($message);
     my %tags = map {$_ => 1} @tags;
-
-    if ($tags{director}) {
-        $tags{private}++;
-    }
 
     if (!$member) {
         $message->reply("I don't know who you are.  Please use /identify <your email address> and then try again.");
@@ -241,8 +238,11 @@ sub read_message ($self, $message) {
         door_log      => {
             match => qr{^/door_log\b},
             help => 'Display the last 10 users of the door (directors-only).'
-        }
-        );
+        },
+        check_valid_members => {
+            match => qr{^/check_valid_members\b},
+            help => 'Check if current group members are valid'
+        });
 
     if (ref($message) eq 'Telegram::Bot::Object::Message' && $message->text) {
         print STDERR $message->text, "\n" if ($message->text =~ q{^/});
@@ -983,7 +983,7 @@ Get the log of the most recent N users of the door.
 =cut
 
 sub door_log ($self, $text, $message) {
-    return unless $self->authorize($message, 'director');
+    return unless $self->authorize($message, 'director', 'private');
 
     my $door_id = $self->db->resultset('Tool')->find({name => "The Door"})->id;
     my $n = 10;
@@ -1006,6 +1006,68 @@ sub door_log ($self, $text, $message) {
     $out = "<pre>$out</pre>";
 
     return $message->reply($out, { parse_mode => 'html' } );
+}
+
+=head2 check_valid_members
+
+=cut
+
+sub check_valid_members ($self, $text, $message) {
+    return unless $self->authorize($message, 'director');
+
+    if ($text =~ m{^/check_valid_members\s*(\d+)?$}) {
+        my $months = $1;
+        $months ||= 6;
+
+        my $dtf = $self->db->storage->datetime_parser;
+        my $now = DateTime->now();
+        my $n_months = $now->clone->subtract(months => $months);
+
+        # fetch all members whose expiry dates are a) expired b) in
+        # the last N months, and have a telegram chatid set
+
+        ## oops this returns one entry per payment row, we only care
+        ## about the  most recent payment
+        ## fetch payments first (max per person?)
+        my $recent_payments_rs = $self->db->resultset('Dues')->search_rs(
+            { },
+            {
+                columns => ['person_id', { 'max_expires' => { max => 'expires_on_date', '-as' => 'max_expires'}}],
+                group_by => 'person_id',
+            });
+
+        my $ex_members_rs = $recent_payments_rs->as_subselect_rs->search_rs(
+            {
+                'me.max_expires' =>
+                { '-between' => [ $dtf->format_datetime($n_months),
+                                  $dtf->format_datetime($now)],
+                },
+                    'person.telegram_chatid' => { '!=' => undef },
+            },
+            {
+                select => ['person.id', 'person.telegram_chatid', 'person.name'],
+                as     => ['p_id', 'p_telegram_chatid', 'p_name'],
+                join => 'person',
+            });
+
+        print STDERR "check_valid_members, found ", $ex_members_rs->count, " ex members in $months\n";
+        my @in_names = ();
+        my $in_count = 0;
+        while(my $db_member = $ex_members_rs->next) {
+            # yup could also be empty string..
+            next if !$db_member->get_column('p_telegram_chatid');
+            my $chat_member = $message->_brain->getChatMember($message->chat->id, $db_member->get_column('p_telegram_chatid'));
+            if($chat_member) {
+                push @in_names, $db_member->get_column('p_name');
+                $in_count++;
+            }
+            # rate limit is 30 calls per second
+            usleep 33;
+        }
+        my $response = "Found $in_count members who shouldn't be here:" . join("\n", @in_names);
+        return $message->reply($response);
+    }
+    return  $message->reply("Usage: /check_valid_members <months> (optional)\n");
 }
 
 =head1 generic_keyboard


### PR DESCRIPTION
API endpoint for "remove ex-member-inductions" (if older than 3 mo)

Fixes #84

Intended for calling from a scheduled job (or as part of the payment
job)

Starts a new Controller which should ideally have some sorta auth
protection so it can't be called by just anybody..
