### PR TITLE
A person may have multiple bank transactions per day

### DIFF
--- a/lib/AccessSystem/Schema/Result/Person.pm
+++ b/lib/AccessSystem/Schema/Result/Person.pm
@@ -446,7 +446,8 @@ sub import_transaction {
     my $dt_parser = $schema->storage->datetime_parser;
     warn "$transaction->{dtposted}\n";
     my $trans_search = $self->search_related('transactions')->search(
-        { added_on => $dt_parser->format_datetime($transaction->{dtposted}) });
+        { added_on => $dt_parser->format_datetime($transaction->{dtposted}),
+        amount_p => $transaction->{trnamt} * 100 });
     if($trans_search->count) {
         warn "Already imported transaction $transaction->{name} $transaction->{dtposted}\n";
         return 1;

--- a/lib/AccessSystem/Schema/Result/Transactions.pm
+++ b/lib/AccessSystem/Schema/Result/Transactions.pm
@@ -26,7 +26,7 @@ __PACKAGE__->add_columns(
     },
 );
 
-__PACKAGE__->set_primary_key('person_id', 'added_on');
+__PACKAGE__->set_primary_key('person_id', 'added_on', 'amount_p');
 __PACKAGE__->belongs_to('person', 'AccessSystem::Schema::Result::Person', 'person_id');
 
 1;

--- a/root/assets/json/prices.json
+++ b/root/assets/json/prices.json
@@ -1,16 +1,21 @@
 {
     "prices":
     {
-        "disposable cup": 5,
+        "disposable cup": 15,
         "can (diet)": 30,
         "can (full)": 40,
+        "can (coca cola)": 60,
         "ribena"    : 75,
         "pot noodles": 100,
         "crisps"    : 40,
-        "small choc bar": 25,
-        "large choc bar": 40,
-        "pork scratchings": 50,
-        "beef jerky": 50,
-        "laser job": 100
+        "crisps (grab bag)"    : 80,
+        "small choc bar": 30,
+        "choc biscuits (large)": 40,
+        "large choc bar": 60,
+        "pork scratchings": 100,
+        "beef jerky": 115,
+        "peanuts": 50,
+        "smarties": 70,
+        "fruit pastilles": 75
     }
 }


### PR DESCRIPTION
Previously (until someone had a mishap and paid £1 less than they intended), the database insisted on only one transaction per person, per day. Can't remember why, somewhat arbitrary - now it allows one per person per day per amount !
